### PR TITLE
Allow BLE connections via device name for macOS compatibility.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,18 @@ Command line interface, simple REST server are also included.
 
 Tested with:
 
+Windows:
+
 * Windows 10
 * Bluetooth adapter (TP-LINK UB500)
 * USB serial connection
 * Printers: B1, D110
+
+Mac:
+
+* macOS 15.5
+* Integrated Bluetooth adapter
+* Printer: D110
 
 Usage example:
 
@@ -31,6 +39,11 @@ Windows requirements:
 * [MS Build tools 2019+](https://visualstudio.microsoft.com/downloads/?q=build+tools)
   - C++ build tools with `Windows SDK >=22000` must be installed
 * Python 3
+
+Mac requirements:
+
+* [Xcode](https://apps.apple.com/ca/app/xcode/id497799835)
+* Permissions: Open "System Settings" → "Privacy & Security" → "Bluetooth" and then add your terminal to allowed applications.
 
 See [node-gyp](https://github.com/nodejs/node-gyp) and [noble](https://github.com/abandonware/noble) installation.
 
@@ -70,6 +83,14 @@ D110 BLE:
 
 ```bash
 niimblue-cli print -d -t ble -a 26:03:03:c3:f9:11 -p D110 -o left label_15x30.png
+```
+
+D110 BLE via name:
+
+_Connecting via the Bluetooth device name instead of address is required on macOS. Find the device name with `niimblue-cli scan -t ble`._
+
+```bash
+niimblue-cli print -d -t ble -a 'D110-XXXXXXXXXX' -p D110 -o left -w 192 -h 96 label_15x30.png
 ```
 
 B1 serial, long parameter names (will resize image to fit 50x30 label, keeping aspect ratio):

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -28,7 +28,7 @@ program
   .addOption(
     new Option("-t, --transport <type>", "Transport").makeOptionMandatory().choices(["ble", "serial"] as TransportType[])
   )
-  .requiredOption("-a, --address <string>", "Device bluetooth address or serial port name/path")
+  .requiredOption("-a, --address <string>", "Device bluetooth address/name or serial port name/path")
   .action(cliPrinterInfo);
 
 program
@@ -48,7 +48,7 @@ program
   .addOption(
     new Option("-t, --transport <type>", "Transport").makeOptionMandatory().choices(["ble", "serial"] as TransportType[])
   )
-  .requiredOption("-a, --address <string>", "Device bluetooth address or serial port name/path")
+  .requiredOption("-a, --address <string>", "Device bluetooth address/name or serial port name/path")
   .addOption(new Option("-o, --print-direction <dir>", "Print direction").choices(["left", "top"] as PrintDirection[]))
   .addOption(new Option("-p, --print-task <type>", "Print task").choices(printTaskNames))
   .requiredOption("-l, --label-type <type number>", "Label type", intOption, 1)
@@ -97,7 +97,7 @@ program
   .addOption(
     new Option("-t, --transport <type>", "Transport").makeOptionMandatory().choices(["ble", "serial"] as TransportType[])
   )
-  .requiredOption("-a, --address <string>", "Device bluetooth address or serial port name/path")
+  .requiredOption("-a, --address <string>", "Device bluetooth address/name or serial port name/path")
   .requiredOption("-f, --file <path>", "Firmware path")
   .requiredOption("-n, --new-version <version>", "New firmware version")
   .action(cliFlashFirmware);

--- a/src/client/headless_ble_impl.ts
+++ b/src/client/headless_ble_impl.ts
@@ -24,9 +24,9 @@ export class NiimbotHeadlessBleClient extends NiimbotAbstractClient {
     super();
   }
 
-  /** Set device mac address for connect */
+  /** Set device mac address or name for connect */
   public setAddress(address: string) {
-    this.addr = address.toLowerCase();
+    this.addr = address;
   }
 
   public static async waitAdapterReady(): Promise<void> {
@@ -88,7 +88,10 @@ export class NiimbotHeadlessBleClient extends NiimbotAbstractClient {
       let timer: NodeJS.Timeout | undefined;
 
       noble.on("discover", async (peripheral: noble.Peripheral) => {
-        if (peripheral.address === address) {
+        if (
+          peripheral.address === address.toLowerCase() ||
+          peripheral.advertisement.localName === address
+        ) {
           clearTimeout(timer);
           resolve(peripheral);
         }
@@ -155,7 +158,7 @@ export class NiimbotHeadlessBleClient extends NiimbotAbstractClient {
     await this.disconnect();
 
     if (!this.addr) {
-      throw new Error("Device address not set");
+      throw new Error("Device address or name not set");
     }
 
     await this.connectToDevice(this.addr);


### PR DESCRIPTION
Hi, thanks for an excellent library!

I ran into a bit of trouble connecting to a D110 via Bluetooth on macOS. Even after getting the Printer's Bluetooth address from the System Report, it refused to connect.

For example, this always failed to connect even when the address value was known to be correct:

```sh
niimblue-cli print -d -t ble -a 04:19:EC:5E:61:20 -p D110 -w 192 -h 96 -o left ./label_15x30.png
```

Some digging indicated that `peripheral.address` is always `unknown` on the Mac, probably a privacy thing. We do, however, have access to `peripheral.advertisement.localName`.

This PR adds support for specifying the printer via the Bluetooth `localName` in addition to the device address. To keep it simple, I overloaded the `-a` flag to accept either type.

For example, this now works on macOS:

```sh
niimblue-cli print -d -t ble -a 'D110-EC19040871' -p D110 -w 192 -h 96 -o left ./label_15x30.png
```

Users can find the name using `niimblue-cli scan -t ble`, and pass that into the `-a` argument.

Implementation notes:

- This should work on Windows as well, but I have not tested it.
- Server functionality was also tested on macOS with this change and confirmed to work.
- BLE device names are case sensitive, so case normalization now only applies to the device address code path.
- Note that I only ran into the address-based connection issues in Node — the [Web Bluetooth example](https://github.com/MultiMote/niimbluelib/tree/main/aexample) in your niimbluelib repo already works fine on macOS. I assume Web Bluetooth device selection is happening via a higher-level and more trusted abstraction than we have access to thorugh noble.

Security notes:

- On Windows and probably Linux, It's theoretically possible that a `localName` of one device could collide with the `address` of another, which could lead the user to accidentally send label data to the wrong device. Seems pretty unlikely but might merit a warning.
