### PR TITLE
Bump niimbluelib alpha

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@commander-js/extra-typings": "^12.1.0",
-        "@mmote/niimbluelib": "0.0.1-alpha.32",
+        "@mmote/niimbluelib": "^0.0.1-alpha.40",
         "@stoprocent/noble": "^2.3.10",
         "async-mutex": "^0.5.0",
         "commander": "^12.1.0",
@@ -27,22 +27,20 @@
       }
     },
     "node_modules/@capacitor-community/bluetooth-le": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@capacitor-community/bluetooth-le/-/bluetooth-le-7.1.1.tgz",
-      "integrity": "sha512-Z5beNgHNQodKaWrjplYUHji3f15nU2/JCA+INzgybK6mBssq/WsHzBw8eBP/CXzAv1XZD6tXMZlLumzAXgZuhw==",
-      "license": "MIT",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@capacitor-community/bluetooth-le/-/bluetooth-le-8.2.0.tgz",
+      "integrity": "sha512-wsy2h9sVcXaynyb3Nf9fVZklnQHDtIfT4fc6iL9McZvi19rDJ5aCoEBqa4wch5RywbF3Ic1W/StKuHJuWUumiQ==",
       "dependencies": {
         "@types/web-bluetooth": "^0.0.20"
       },
       "peerDependencies": {
-        "@capacitor/core": ">=7.0.0"
+        "@capacitor/core": ">=8.0.0"
       }
     },
     "node_modules/@capacitor/core": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-7.3.0.tgz",
-      "integrity": "sha512-t/DdTyBchQ2eAZuCmAARlqQsrEm0WyeNwh5zeRuv+cR6gnAsw+86/EWvJ/em5dTnZyaqEy8vlmOMdWarrUbnuQ==",
-      "license": "MIT",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-8.4.0.tgz",
+      "integrity": "sha512-LrS1xPIrqLtJABBIPDGXxxKmI9OyesrzWw8DiHbxhSC9JoiLUleUAJlX1a0LWIVLRbuY4Szgf9huFeRqYH2SAQ==",
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -427,16 +425,15 @@
       }
     },
     "node_modules/@mmote/niimbluelib": {
-      "version": "0.0.1-alpha.32",
-      "resolved": "https://registry.npmjs.org/@mmote/niimbluelib/-/niimbluelib-0.0.1-alpha.32.tgz",
-      "integrity": "sha512-coK/y6ehok3aJMIEKP8tnbDyu4iiz9N/ew7GVJ6EuGxwLXnuXWTDlGQjKcCqZFCzuk7k3q8anifDxQePEQNcAA==",
-      "license": "MIT",
+      "version": "0.0.1-alpha.40",
+      "resolved": "https://registry.npmjs.org/@mmote/niimbluelib/-/niimbluelib-0.0.1-alpha.40.tgz",
+      "integrity": "sha512-3y4u4GT5T9rDi3FOdF7MnI6muYC+gEscyp14MiBs1tFqS3zd9E5bprHphm9wJeWQbttKue9o7IQrLn6bbTFpww==",
       "dependencies": {
-        "@capacitor-community/bluetooth-le": "^7.1.0",
-        "@capacitor/core": "^7.2.0",
+        "@capacitor-community/bluetooth-le": "^8.1.3",
+        "@capacitor/core": "^8.3.0",
         "async-mutex": "^0.5.0",
         "crc-32": "^1.2.2",
-        "eventemitter3": "^5.0.1"
+        "eventemitter3": "^5.0.4"
       }
     },
     "node_modules/@serialport/binding-mock": {
@@ -781,8 +778,7 @@
     "node_modules/@types/web-bluetooth": {
       "version": "0.0.20",
       "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.20.tgz",
-      "integrity": "sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==",
-      "license": "MIT"
+      "integrity": "sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow=="
     },
     "node_modules/@yarnpkg/lockfile": {
       "version": "1.1.0",
@@ -1085,9 +1081,9 @@
       }
     },
     "node_modules/eventemitter3": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="
     },
     "node_modules/fill-range": {
       "version": "7.1.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@commander-js/extra-typings": "^12.1.0",
-    "@mmote/niimbluelib": "0.0.1-alpha.32",
+    "@mmote/niimbluelib": "^0.0.1-alpha.40",
     "@stoprocent/noble": "^2.3.10",
     "async-mutex": "^0.5.0",
     "commander": "^12.1.0",


### PR DESCRIPTION
## Summary

Updates `@mmote/niimbluelib` from `0.0.1-alpha.32` to `^0.0.1-alpha.40` so niimblue-node picks up the wait-status fix referenced in #5.

The lockfile was regenerated to match alpha.40 and its updated transitive dependencies.

## Validation

- `npm run build`
