### PR TITLE
feat: Support multi-image printing in CLI and server (closes #10)

### DIFF
--- a/docs/server/openapi3_0.yaml
+++ b/docs/server/openapi3_0.yaml
@@ -46,6 +46,7 @@ paths:
                   $ref: "#/components/schemas/SimpleResponse"
         "500":
             description: Connection failure
+
   /disconnect:
     post:
       summary: Disconnect from the printer
@@ -78,6 +79,7 @@ paths:
                 properties:
                   connected:
                     type: boolean
+
   /info:
     get:
       summary: Check the printer info
@@ -102,7 +104,16 @@ paths:
 
   /print:
     post:
-      summary: Print image
+      summary: Print image(s)
+      description: >
+        Prints one or more images to the printer. This endpoint supports 
+        two payload structures:
+
+        1. Single-Image Mode: Supply a single image using the root-level 
+        `imageUrl` or `imageBase64` fields.
+
+        2. Multi-Page Mode: Use the `pages` array to send multiple distinct images 
+        in a single print job.
       requestBody:
         required: true
         content:
@@ -113,7 +124,8 @@ paths:
               Print base64 image:
                 value:
                   printDirection: top
-                  imageBase64: "iVBORw0KGgoAAAANSUhEUgAAAVgAAADICAAAAACIFqZrAAAA1GlDQ1BpY2MAABiVdZBBCwFBHMXfauPioMhBig9gSyk5kuKyHBaFXNZYS3bXNLubfC/fRPkMDs7O3koOWv/pP+/1b34zvQG0lSf8UO8CfhCpodVbzBfLeu6OPLIoooyaLUI5mgym+FvPG7REr0Zy1/9zqaVvnFBQL+y2kCqiPtjmKZL0Woe+dJhafXqTvuB7sfiwyat5J5hNqBV2FS4UbJxRxxox9vAQwaAGzJfONd/cGEcygrskrUi42JFtcBojhEPdcu5weTgnf/SbXdrK/qbKtFov/qczRp9clewAAAAJcEhZcwAACxIAAAsSAdLdfvwAAAIwSURBVHja7d3BTsJQEIZRx/D+rzxGpLRAoRpL/C+ebyGiLsxhHKQsbvWbntE7ArBgBfZpHY4fC8SOtYm1CkZdBdP86reVibUKwAosWLACCxaswIIFK7BgwQosWLACCxaswIIFK7BgwQosWLACCxaswIIFK7BgwQosWLACCxaswIIFK7BgwQosWLACCxaswIIFK7BgwQosWLACCxaswIIFK7BgweoJHSJ+izvHXo18/o2JBbs19Vmnvb0MbIWdo5exY3vB8yJHi73KxMad+pgxsdtow01xPGxNN724f706avmzGY9B+iqY/8SXz/oVvgfyYevmTj/+CtifuHbfjO/F/SVthzhH79h5Z/aM2sfP6uy3+HbS7Ob/u9WLm9VnrsySYe/BnYyzX0yM+wIh/CD4Uf6PvRzZutoTJnanOt7V9ViwgxW/Y0e9hjjmxNbVLdh9XZNlR4RdXh2MlU2G7UdyHb598ye2Vr/QW/Bgt0b2dIW7PluTrAePwR82wnteK2Bf5PNL2+li4vw9E7s9suuL4C17GYTv2Mv3A3pdMfL6YU0PevBz7LfffA14n/z8K4ywY3v3H7QKxg0sWLACCxaswIIFK7BgwQosWLACCxaswIIFK7BgwQosWLACCxaswIIFK7BgwQosWLACCxaswIIFK7BgwQosWLACCxaswIIFK7BgwQosWLACCxaswIIFK7BgwQosWLACm9/5dKTww99NrMA+tRr1bG0TC1Zgwf7fPgCwK0CxpUdwQgAAAABJRU5ErkJggg=="
+                  imageBase64: "iVBORw0KGgoAAAANSUhEUgAAAVgAAADICAAAAACIFqZrAAAA1GlDQ1BpY2MAABiVdZBBCwFBHMXfauPioMhBig9gSyk5kuKyHBaFXNZYS3bXNLubfC/fRPkMDs7O3koOWv/pP+/1b34zvQG0lSf8UO8CfhCpodVbzBfLeu6OPLIoooyaLUI5mgym+FvPG7REr0Zy1/9zqaVvnFBQL+y2kCqiPtjmKZL0Woe+dJhafXqTvuB7sfiwyat5J5hNqBV2FS4UbJxRxxox9vAQwaAGzJfONd/cGEcygrskrUi42JFtcBojhEPdcu5weTgnf/SbXdrK/qbKtFov/qczRp9clewAAAAJcEhZcwAACxIAAAsSAdLdfvwAAAIwSURBVHja7d3BTsJQEIZRx/D+rzxGpLRAoRpL/C+ebyGiLsxhHKQsbvWbntE7ArBgBfZpHY4fC8SOtYm1CkZdBdP86reVibUKwAosWLACCxaswIIFK7BgwQosWLACCxaswIIFK7BgwQosWLACCxaswIIFK7BgwQosWLACCxaswIIFK7BgwQosWLACCxaswIIFK7BgwQosWLACCxaswIIFK7BgwQosWLACm9/hdKTww99NrMA+tRr1bG0TC1Zgwf7fPgCwK0CxpUdwQgAAAABJRU5ErkJggg=="
+
               Print from url:
                 value:
                   quantity: 1
@@ -126,6 +138,19 @@ paths:
                   imageFit: contain
                   threshold: 128
                   density: 3
+
+              Print multiple pages:
+                value:
+                  printDirection: left
+                  printTask: B1
+                  density: 3
+                  labelType: 1
+                  quantity: 1
+                  pages:
+                    - imageUrl: https://i.imgur.com/TzzVlc4.png
+                      quantity: 2
+                    - imageBase64: "iVBORw0KGgoAAAANSUhEUgAAAVgAAADICAAAAACIFqZrAAAA..."
+                      quantity: 1
 
       responses:
         "200":
@@ -176,7 +201,6 @@ paths:
                 required:
                   - devices
 
-
 components:
   schemas:
     SimpleResponse:
@@ -187,8 +211,30 @@ components:
         message:
           type: string
 
+    PageObject:
+      type: object
+      description: A single page to be printed. Exactly one of imageUrl or imageBase64 must be provided.
+      properties:
+        imageBase64:
+          type: string
+          format: byte
+          description: Base64-encoded image data.
+        imageUrl:
+          type: string
+          format: uri
+          description: Publicly accessible image URL.
+        quantity:
+          type: number
+          minimum: 1
+          description: How many copies of this page to print.
+      required: []
+
     PrintOptions:
       type: object
+      description: >
+        Print parameters. You must provide exactly one of:
+          - `imageUrl` or `imageBase64`, or
+          - `pages` (multi-page mode).
       properties:
         printDirection:
           type: string
@@ -198,11 +244,13 @@ components:
         printTask:
           type: string
           example: B1
+          description: Printer task type (if omitted, auto-detected).
 
         quantity:
           type: number
           minimum: 1
           default: 1
+          description: Global quantity applied to all pages unless overridden per page.
 
         labelType:
           type: number
@@ -217,27 +265,34 @@ components:
         imageBase64:
           type: string
           format: byte
-          default: null
-          description: imageUrl or imageBase64 must be defined
+          description: |
+            Image as base64-encoded string. Use either this or `imageUrl`.
 
         imageUrl:
           type: string
           format: uri
-          default: null
-          example: https://i.imgur.com/TzzVlc4.png
-          description: imageUrl or imageBase64 must be defined
+          description: |
+            Image URL. Use either this or `imageBase64`.
+
+        pages:
+          type: array
+          minItems: 1
+          items:
+            $ref: "#/components/schemas/PageObject"
+          description: |
+            Array of pages to print. Each page requires exactly one image source
+            (`imageUrl` or `imageBase64`) and can have its own `quantity`.
+            Cannot be combined with `imageUrl`/`imageBase64` fields.
 
         labelWidth:
-          description: Retrieved from image if not set
+          description: Label width in pixels (if omitted, the image's original width is used).
           type: number
           minimum: 8
-          default: null
 
         labelHeight:
-          description: Retrieved from image if not set
+          description: Label height in pixels (if omitted, the image's original height is used).
           type: number
           minimum: 8
-          default: null
 
         threshold:
           type: number
@@ -256,6 +311,11 @@ components:
           enum: ["contain", "cover", "fill", "inside", "outside"]
           default: contain
           description: See [sharp resize options.fit](https://sharp.pixelplumbing.com/api-resize)
+
+        waitUntilFinished:
+          type: boolean
+          default: true
+          description: If false, the HTTP response is returned immediately while the print job runs in the background.
 
     PrinterInfo:
       type: object

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -54,7 +54,7 @@ program
 program
   .command("print")
   .description("Prints image")
-  .argument("<path>", "PNG image path")
+  .argument("<paths...>", "PNG image path(s). Multiple files, or a shell glob like *.png, will be printed in one session.")
   .requiredOption("-d, --debug", "Debug information", false)
   .addOption(
     new Option("-t, --transport <type>", "Transport").makeOptionMandatory().choices(["ble", "serial"] as TransportType[])

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -54,7 +54,7 @@ program
 program
   .command("print")
   .description("Prints image")
-  .argument("<paths...>", "PNG image path(s). Multiple files, or a shell glob like *.png, will be printed in one session.")
+  .argument("<paths...>", "PNG image path(s)")
   .requiredOption("-d, --debug", "Debug information", false)
   .addOption(
     new Option("-t, --transport <type>", "Transport").makeOptionMandatory().choices(["ble", "serial"] as TransportType[])

--- a/src/cli/worker.ts
+++ b/src/cli/worker.ts
@@ -122,7 +122,6 @@ export const cliConnectAndPrintImageFile = async (paths: string[], options: Prin
 
   try {
     // Decode/encode all pages up front, then print them as a single multi-page task
-    // so the printer isn't re-initialized (and doesn't re-cut/re-calibrate) between files.
     const pages: Awaited<ReturnType<typeof ImageEncoder.encodeImage>>[] = [];
     let printTaskName: PrintTaskName | undefined;
 

--- a/src/cli/worker.ts
+++ b/src/cli/worker.ts
@@ -10,7 +10,7 @@ import {
 import fs from "fs";
 import sharp from "sharp";
 import { ImageEncoder } from "..";
-import { initClient, loadImageFromFile, printImage, TransportType } from "../utils";
+import { initClient, loadImageFromFile, printImages, TransportType } from "../utils";
 import { InvalidArgumentError } from "@commander-js/extra-typings";
 
 export type SharpImageFit = "contain" | "cover" | "fill" | "inside" | "outside";
@@ -64,15 +64,11 @@ export interface PrintOptions {
   debug: boolean;
 }
 
-export const cliConnectAndPrintImageFile = async (path: string, options: PrintOptions & TransportOptions) => {
-  const client: NiimbotAbstractClient = initClient(options.transport, options.address, options.debug);
-
-  if (options.debug) {
-    console.log("Connecting to", options.transport, options.address);
-  }
-
-  await client.connect();
-
+const encodeSingleImage = async (
+  client: NiimbotAbstractClient,
+  path: string,
+  options: PrintOptions
+): Promise<{ encoded: Awaited<ReturnType<typeof ImageEncoder.encodeImage>>; printTask: PrintTaskName }> => {
   let image: sharp.Sharp = await loadImageFromFile(path);
 
   image = image.flatten({ background: "#fff" }).threshold(options.threshold);
@@ -84,32 +80,88 @@ export const cliConnectAndPrintImageFile = async (path: string, options: PrintOp
       position: options.imagePosition ?? "center",
       background: "#fff",
     });
-  } else if(options.imageFit !== undefined || options.imagePosition !== undefined) {
+  } else if (options.imageFit !== undefined || options.imagePosition !== undefined) {
     throw new InvalidArgumentError("label-width and label-height must be set");
   }
 
   const printDirection: PrintDirection | undefined = options.printDirection ?? client.getModelMetadata()?.printDirection;
   const printTask: PrintTaskName | undefined = options.printTask ?? client.getPrintTaskType();
 
-  const encoded = await ImageEncoder.encodeImage(image, printDirection);
-
   if (printTask === undefined) {
     throw new Error("Unable to detect print task, please set it manually");
   }
 
-  if (options.debug) {
-    console.log("Print task:", printTask);
+  const encoded = await ImageEncoder.encodeImage(image, printDirection);
+
+  return { encoded, printTask };
+};
+
+export const cliConnectAndPrintImageFile = async (paths: string[], options: PrintOptions & TransportOptions) => {
+  if (paths.length === 0) {
+    console.error("Error: No files provided");
+    process.exit(1);
   }
 
-  let status = 1;
+  const missing = paths.filter((p) => !fs.existsSync(p));
+  if (missing.length > 0) {
+    for (const m of missing) {
+      console.error(`Error: File not found: ${m}`);
+    }
+    process.exit(1);
+  }
+
+  const client: NiimbotAbstractClient = initClient(options.transport, options.address, options.debug);
+
+  if (options.debug) {
+    console.log("Connecting to", options.transport, options.address);
+  }
+
+  await client.connect();
+
+  let status = 0;
 
   try {
-    await printImage(client, printTask, encoded, {
-      quantity: options.quantity,
-      labelType: options.labelType,
-      density: options.density,
-    });
-    status = 0;
+    // Decode/encode all pages up front, then print them as a single multi-page task
+    // so the printer isn't re-initialized (and doesn't re-cut/re-calibrate) between files.
+    const pages: Awaited<ReturnType<typeof ImageEncoder.encodeImage>>[] = [];
+    let printTaskName: PrintTaskName | undefined;
+
+    for (let i = 0; i < paths.length; i++) {
+      const path = paths[i];
+
+      if (paths.length > 1) {
+        console.log(`Encoding file ${i + 1}/${paths.length}: ${path}`);
+      }
+
+      const { encoded, printTask } = await encodeSingleImage(client, path, options);
+
+      if (printTaskName === undefined) {
+        printTaskName = printTask;
+        if (options.debug) {
+          console.log("Print task:", printTaskName);
+        }
+      }
+
+      pages.push(encoded);
+    }
+
+    if (printTaskName === undefined) {
+      throw new Error("Unable to detect print task, please set it manually");
+    }
+
+    await printImages(
+      client,
+      printTaskName,
+      pages.map((encoded) => ({ encoded })),
+      {
+        quantity: options.quantity,
+        labelType: options.labelType,
+        density: options.density,
+      }
+    );
+  } catch (err) {
+    console.error("Error printing:", err instanceof Error ? err.message : err);
+    status = 1;
   } finally {
     await client.disconnect();
   }

--- a/src/server/simple_server.ts
+++ b/src/server/simple_server.ts
@@ -23,7 +23,10 @@ export const writeObj = (response: http.ServerResponse, o: unknown, status: numb
   response.end(JSON.stringify(o));
 };
 
-export const readBodyJson = async <T>(request: http.IncomingMessage, schema: z.ZodType<T>): Promise<T> => {
+export const readBodyJson = async <S extends z.ZodTypeAny>(
+  request: http.IncomingMessage,
+  schema: S
+): Promise<z.output<S>> => {
   return new Promise((resolve, reject) => {
     const bodyParts: any[] = [];
 
@@ -47,7 +50,7 @@ export const readBodyJson = async <T>(request: http.IncomingMessage, schema: z.Z
 
         const result = schema.safeParse(data);
         if (result.success) {
-          resolve(result.data);
+          resolve(result.data as z.output<S>);   // cast is safe
         } else {
           reject(result.error);
         }

--- a/src/server/simple_server.ts
+++ b/src/server/simple_server.ts
@@ -50,7 +50,7 @@ export const readBodyJson = async <S extends z.ZodTypeAny>(
 
         const result = schema.safeParse(data);
         if (result.success) {
-          resolve(result.data as z.output<S>);   // cast is safe
+          resolve(result.data as z.output<S>);
         } else {
           reject(result.error);
         }

--- a/src/server/worker.ts
+++ b/src/server/worker.ts
@@ -11,7 +11,7 @@ import { IncomingMessage } from "http";
 import sharp from "sharp";
 import { z } from "zod";
 import { ImageEncoder } from "../image_encoder";
-import { initClient, loadImageFromBase64, loadImageFromUrl, printImage } from "../utils";
+import { initClient, loadImageFromBase64, loadImageFromUrl, printImages, PrintPage } from "../utils";
 import { readBodyJson, RestError } from "./simple_server";
 
 let client: NiimbotAbstractClient | null = null;
@@ -29,6 +29,19 @@ const ScanSchema = z.object({
 
 const [firstTask, ...otherTasks] = printTaskNames;
 
+const PageSchema = z
+  .object({
+    imageBase64: z.string().optional(),
+    imageUrl: z.string().optional(),
+    quantity: z.number().min(1).optional(),
+  })
+  .refine(
+    ({ imageUrl, imageBase64 }) => {
+      return !!imageUrl !== !!imageBase64;
+    },
+    { message: "imageUrl or imageBase64 must be defined", path: ["image"] }
+  );
+
 const PrintSchema = z
   .object({
     printDirection: z.enum(["left", "top"]).optional(),
@@ -38,6 +51,7 @@ const PrintSchema = z
     density: z.number().min(1).default(3),
     imageBase64: z.string().optional(),
     imageUrl: z.string().optional(),
+    pages: z.array(PageSchema).min(1).optional(),
     labelWidth: z.number().positive().optional(),
     labelHeight: z.number().positive().optional(),
     threshold: z.number().min(1).max(255).default(128),
@@ -45,12 +59,26 @@ const PrintSchema = z
       .enum(["centre", "center", "top", "right top", "right", "right bottom", "bottom", "left bottom", "left", "left top"])
       .default("center"),
     imageFit: z.enum(["contain", "cover", "fill", "inside", "outside"]).default("contain"),
+    waitUntilFinished: z.boolean().default(true),
   })
   .refine(
+    ({ imageUrl, imageBase64, pages }) => {
+      // Either the legacy single-image shape, or the new `pages` array, must be provided (not both).
+      const hasSingleImage = !!imageUrl || !!imageBase64;
+      const hasPages = !!pages;
+      return hasSingleImage !== hasPages;
+    },
+    { message: "Provide either imageUrl/imageBase64 or pages, but not both", path: ["image"] }
+  )
+  .refine(
     ({ imageUrl, imageBase64 }) => {
+      if (!imageUrl && !imageBase64) {
+        // handled by the pages branch above
+        return true;
+      }
       return !!imageUrl !== !!imageBase64;
     },
-    { message: "imageUrl or imageBase64 must be defined", path: ["image"] }
+    { message: "imageUrl or imageBase64 must be defined, not both", path: ["image"] }
   );
 
 export const setDebug = (v: boolean): void => {
@@ -113,17 +141,17 @@ export const rfid = async () => {
   return { paperRfidInfo, ribbonRfidInfo };
 };
 
-export const print = async (r: IncomingMessage) => {
-  assertConnected();
-
-  const options = await readBodyJson(r, PrintSchema);
-
+const prepareImage = async (
+  options: z.infer<typeof PrintSchema>,
+  imageBase64: string | undefined,
+  imageUrl: string | undefined
+): Promise<sharp.Sharp> => {
   let image: sharp.Sharp;
 
-  if (options.imageBase64 !== undefined) {
-    image = await loadImageFromBase64(options.imageBase64);
-  } else if (options.imageUrl !== undefined) {
-    image = await loadImageFromUrl(options.imageUrl);
+  if (imageBase64 !== undefined) {
+    image = await loadImageFromBase64(imageBase64);
+  } else if (imageUrl !== undefined) {
+    image = await loadImageFromUrl(imageUrl);
   } else {
     throw new RestError("Image is not defined", 400);
   }
@@ -139,14 +167,16 @@ export const print = async (r: IncomingMessage) => {
     });
   }
 
-  image = image.threshold(options.threshold);
+  return image.threshold(options.threshold);
+};
 
-  // await image.toFile("tmp.png");
+export const print = async (r: IncomingMessage) => {
+  assertConnected();
+
+  const options = await readBodyJson(r, PrintSchema);
 
   const printDirection: PrintDirection | undefined = options.printDirection ?? client!.getModelMetadata()?.printDirection;
   const printTask: PrintTaskName | undefined = options.printTask ?? client!.getPrintTaskType();
-
-  const encoded = await ImageEncoder.encodeImage(image, printDirection);
 
   if (printTask === undefined) {
     throw new RestError("Unable to detect print task, please set it manually", 400);
@@ -156,13 +186,35 @@ export const print = async (r: IncomingMessage) => {
     console.log("Print task:", printTask);
   }
 
-  await printImage(client!, printTask, encoded, {
+  // Normalize both the legacy single-image shape and the new `pages` array
+  // into a single list of pages to be printed as one multi-page job.
+  const pageInputs = options.pages ?? [{ imageBase64: options.imageBase64, imageUrl: options.imageUrl, quantity: options.quantity }];
+
+  const pages: PrintPage[] = [];
+
+  for (const p of pageInputs) {
+    const image = await prepareImage(options, p.imageBase64, p.imageUrl);
+    const encoded = await ImageEncoder.encodeImage(image, printDirection);
+    pages.push({ encoded, quantity: p.quantity });
+  }
+
+  const printJob = printImages(client!, printTask, pages, {
     quantity: options.quantity,
     labelType: options.labelType,
     density: options.density,
   });
 
-  return { message: "Printed" };
+  if (options.waitUntilFinished) {
+    await printJob;
+    return { message: "Printed" };
+  }
+
+  // Fire-and-forget: don't block the HTTP response on the printer finishing.
+  printJob.catch((err) => {
+    console.error("Print job failed:", err instanceof Error ? err.message : err);
+  });
+
+  return { message: "Print job submitted" };
 };
 
 export const scan = async (r: IncomingMessage) => {

--- a/src/server/worker.ts
+++ b/src/server/worker.ts
@@ -63,7 +63,7 @@ const PrintSchema = z
   })
   .refine(
     ({ imageUrl, imageBase64, pages }) => {
-      // Either the legacy single-image shape, or the new `pages` array, must be provided (not both).
+      // Either the single-image shape, or the `pages` array, must be provided (not both).
       const hasSingleImage = !!imageUrl || !!imageBase64;
       const hasPages = !!pages;
       return hasSingleImage !== hasPages;
@@ -186,8 +186,6 @@ export const print = async (r: IncomingMessage) => {
     console.log("Print task:", printTask);
   }
 
-  // Normalize both the legacy single-image shape and the new `pages` array
-  // into a single list of pages to be printed as one multi-page job.
   const pageInputs = options.pages ?? [{ imageBase64: options.imageBase64, imageUrl: options.imageUrl, quantity: options.quantity }];
 
   const pages: PrintPage[] = [];
@@ -209,7 +207,6 @@ export const print = async (r: IncomingMessage) => {
     return { message: "Printed" };
   }
 
-  // Fire-and-forget: don't block the HTTP response on the printer finishing.
   printJob.catch((err) => {
     console.error("Print job failed:", err instanceof Error ? err.message : err);
   });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,6 +25,13 @@ export interface PrintOptions {
   density?: number;
 }
 
+/** One page of a multi-page print job. */
+export interface PrintPage {
+  encoded: EncodedImage;
+  /** How many copies of this page to print. Defaults to 1. */
+  quantity?: number;
+}
+
 export const initClient = (transport: TransportType, address: string, debug: boolean): NiimbotAbstractClient => {
   let client = null;
   if (transport === "serial") {
@@ -72,27 +79,51 @@ export const initClient = (transport: TransportType, address: string, debug: boo
   return client;
 };
 
-export const printImage = async (
+/**
+ * Prints one or more pages (images) as a single print task/job.
+ * Each page carries its own `quantity` (label copies), falling back to
+ * `options.quantity` (and finally 1) when not set on the page itself.
+ */
+export const printImages = async (
   client: NiimbotAbstractClient,
   printTaskName: PrintTaskName,
-  encoded: EncodedImage,
+  pages: PrintPage[],
   options: PrintOptions
 ) => {
+  const defaultQuantity = options.quantity ?? 1;
+  const resolvedPages = pages.map((p) => ({ encoded: p.encoded, quantity: p.quantity ?? defaultQuantity }));
+  const totalPages = resolvedPages.reduce((sum, p) => sum + p.quantity, 0);
+
   const printTask: AbstractPrintTask = client.abstraction.newPrintTask(printTaskName, {
     density: options.density ?? 3,
     labelType: options.labelType ?? LabelType.WithGaps,
-    totalPages: options.quantity ?? 1,
+    totalPages,
     statusPollIntervalMs: 500,
     statusTimeoutMs: 8_000,
   });
 
   try {
     await printTask.printInit();
-    await printTask.printPage(encoded, options.quantity ?? 1);
+
+    for (const page of resolvedPages) {
+      await printTask.printPage(page.encoded, page.quantity);
+      await printTask.waitForPageFinished();
+    }
+
     await printTask.waitForFinished();
   } finally {
     await printTask.printEnd();
   }
+};
+
+/** @deprecated Use {@link printImages} instead. Kept for backward compatibility. */
+export const printImage = async (
+  client: NiimbotAbstractClient,
+  printTaskName: PrintTaskName,
+  encoded: EncodedImage,
+  options: PrintOptions
+) => {
+  await printImages(client, printTaskName, [{ encoded }], options);
 };
 
 export const loadImageFromBase64 = async (b64: string): Promise<sharp.Sharp> => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -116,16 +116,6 @@ export const printImages = async (
   }
 };
 
-/** @deprecated Use {@link printImages} instead. Kept for backward compatibility. */
-export const printImage = async (
-  client: NiimbotAbstractClient,
-  printTaskName: PrintTaskName,
-  encoded: EncodedImage,
-  options: PrintOptions
-) => {
-  await printImages(client, printTaskName, [{ encoded }], options);
-};
-
 export const loadImageFromBase64 = async (b64: string): Promise<sharp.Sharp> => {
   const buf = Buffer.from(b64, "base64");
   const stream = Readable.from(buf);


### PR DESCRIPTION
This PR adds native multi-image printing to the CLI and corresponding server-side updates to the `/print` endpoint.

Previously, the CLI handled multiple image paths by spawning isolated print tasks sequentially. Running redundant `printInit` ⇄ `printEnd` cycles for each individual label lead to paper slipping out of the printer's paper guide. 

Now, both the CLI and the server leverage `niimbluelib`'s native multi-page task API to execute a single, continuous print job.

---

## 1. CLI Enhancements (Primary Focus)

The `print` command now utilizes the `<paths...>` argument to process multiple files in a single print task.

```bash
niimblue-cli print [options] <paths...>

```

### **How it works now:**

When you pass multiple images to the CLI:

1. It initializes **one** print task with `totalPages`.
2. It dispatches `printPage()` for each image in sequence.
3. It closes with a single `printEnd()` call.

### **Example Usage:**

```bash
niimblue-cli print -t ble -a 27:03:07:17:6e:82 path/to/label1.png path/to/label2.png

```

---

## 2. Server & API Updates

To support this unified behavior, the `/print` endpoint was updated to accept a nested `pages` array.

### **Multi-Page Payload Example**

`POST /print`

```json
{
  "printTask": "B1",
  "density": 3,
  "waitUntilFinished": false,
  "pages": [
    { 
      "imageUrl": "https://i.imgur.com/TzzVlc4.png", 
      "quantity": 2 
    },
    { 
      "imageBase64": "iVBORw0KGgoAAAANSUhEUgAAAVg...", 
      "quantity": 1 
    }
  ]
}

```

* **Backward Compatibility**: Single-image root payloads (`imageUrl` or `imageBase64`) are automatically mapped to a single-item `pages` array internally.


---

## 3. Execution Control: waitUntilFinished

This parameter allows managing the synchronization mode of the print request, determining whether the API call waits for the physical printer to finish before responding.

```json
{
  "printTask": "B1",
  "imageUrl": "https://i.imgur.com/TzzVlc4.png",
  "waitUntilFinished": true
}
```


* **`waitUntilFinished` (Boolean)**:
* `true`: Holds the HTTP connection until the printer finishes.
* `false`: Dispatches the job immediately and returns `200 OK` without blocking.